### PR TITLE
WIP: Allow Generic Types

### DIFF
--- a/src/SolidModeling.jl
+++ b/src/SolidModeling.jl
@@ -25,17 +25,17 @@ function fromPolygons(polygons::Vector{Polygon{T}}) where T
 end
 
 function toPolygons(model::Solid{T}) where T
-    list = Array{Polygon,1}();
+    list = Array{Polygon,1}()
     for i = 0:3:(length(model.indices) - 1)
 
         triangle = Array{T,1}()
         for j = 0:2
             v = model.vertices[model.indices[i + j + 1] + 1]
-            push!(triangle, copy(v));
+            push!(triangle, copy(v))
         end
         push!(list, Polygon{T}(triangle, fromPoints(triangle[1], triangle[2], triangle[3])))
     end
-    return list;
+    return list
 end
 
 """
@@ -65,8 +65,8 @@ function bunion(first::Solid{T}, second::Solid{T}) where T
     a = Node{T}(nothing, nothing, nothing, Array{Polygon{T},1}())
     b = Node{T}(nothing, nothing, nothing, Array{Polygon{T},1}())
 
-    build(a, toPolygons(first));
-    build(b, toPolygons(second));
+    build(a, toPolygons(first))
+    build(b, toPolygons(second))
 
     clipTo(a, b)
     clipTo(b, a)
@@ -105,8 +105,8 @@ function bsubtract(first::Solid{T}, second::Solid{T}) where T
     a = Node{T}(nothing, nothing, nothing, Array{Polygon{T},1}())
     b = Node{T}(nothing, nothing, nothing, Array{Polygon{T},1}())
 
-    build(a, toPolygons(first));
-    build(b, toPolygons(second));
+    build(a, toPolygons(first))
+    build(b, toPolygons(second))
 
     invert(a)
     clipTo(a, b)
@@ -146,8 +146,8 @@ function bintersect(first::Solid{T}, second::Solid{T}) where T
     a = Node{T}(nothing, nothing, nothing, Array{Polygon{T},1}())
     b = Node{T}(nothing, nothing, nothing, Array{Polygon{T},1}())
 
-    build(a, toPolygons(first));
-    build(b, toPolygons(second));
+    build(a, toPolygons(first))
+    build(b, toPolygons(second))
 
     invert(a)
     clipTo(b, a)
@@ -182,7 +182,13 @@ function splitPolygon(plane::Plane{T}, polygon, coplanarFront, coplanarBack, fro
     for i in eachindex(polygon.vertices)
         vertex = polygon.vertices[i]
         t = dot(plane.normal, vertex) - plane.w
-        type = (t < -PlaneEpsilon) ? BACK : ((t > PlaneEpsilon) ? FRONT : COPLANAR)
+        type = if t < -PlaneEpsilon
+            BACK
+        elseif t > PlaneEpsilon
+            FRONT
+        else
+            COPLANAR
+        end
         polygonType |= type
         types[i] = type
     end
@@ -193,7 +199,7 @@ function splitPolygon(plane::Plane{T}, polygon, coplanarFront, coplanarBack, fro
         push!(front, polygon)
     elseif polygonType == BACK
         push!(back, polygon)
-    elseif polygonType == SPANNING
+    else # SPANNING
         f = Array{T,1}()
         b = Array{T,1}()
 
@@ -207,7 +213,7 @@ function splitPolygon(plane::Plane{T}, polygon, coplanarFront, coplanarBack, fro
             if ti != BACK push!(f, copy(vi)) end
             if ti != FRONT push!(b, copy(vi)) end
             if (ti | tj) == SPANNING
-                t = (plane.w - dot(plane.normal, vi)) / dot(plane.normal, vj - vi)
+                t = (plane.w - dot(plane.normal, vi)) / dot(plane.normal, vj .- vi)
                 v = interpolate(vi, vj, t)
                 push!(f, v)
                 push!(b, v)
@@ -245,7 +251,7 @@ function clipPolygons(node::Node{T}, polygons::Array{Polygon{T},1}) where T
     back = Array{Polygon{T},1}()
 
     for polygon in polygons
-        splitPolygon(node.plane, polygon, front, back, front, back);
+        splitPolygon(node.plane, polygon, front, back, front, back)
     end
 
     if node.front !== nothing
@@ -339,9 +345,9 @@ function cube(xMin::Float64, yMin::Float64, zMin::Float64, xMax::Float64, yMax::
     f5p = Polygon([v3, v4, v8, v7], fromPoints(v3, v4, v8))
     f6p = Polygon([v4, v1, v5, v8], fromPoints(v4, v1, v5))
 
-    polys = [f1p, f2p, f3p, f4p, f5p, f6p];
+    polys = [f1p, f2p, f3p, f4p, f5p, f6p]
 
-    return fromPolygons(polys);
+    return fromPolygons(polys)
 end
 
 function signedVolumeOfTriangle(p1, p2, p3)
@@ -367,7 +373,7 @@ julia> volume(cube(0.0, 0.0, 0.0, 1.0, 1.0, 1.0))
 ```
 """
 function volume(c::Solid)::Float64
-    volume = 0.0;
+    volume = 0.0
 
     for i = 0:3:(length(c.indices) - 1)
         dv = signedVolumeOfTriangle(c.vertices[i + 1], c.vertices[i + 2], c.vertices[i + 3])
@@ -377,10 +383,10 @@ function volume(c::Solid)::Float64
     return volume
 end
 
-export cube;
-export bunion;
-export bsubtract;
-export bintersect;
-export volume;
+export cube
+export bunion
+export bsubtract
+export bintersect
+export volume
 
 end # module

--- a/src/SolidModeling.jl
+++ b/src/SolidModeling.jl
@@ -6,19 +6,17 @@ const PlaneEpsilon = 1e-8
 
 include("structs.jl")
 
-function fromPolygons(polygons)
-    csg = Solid(Array{Vertex,1}(), Array{Int64,1}())
+function fromPolygons(polygons::Vector{Polygon{T}}) where T
+    csg = Solid(Vector{T}(), Vector{Int}())
 
-    p::Int64 = 0
+    p = 0
     for i = 0:(length(polygons) - 1)
         poly = polygons[i + 1]
         for j = 2:(length(poly.vertices) - 1)
-            push!(csg.vertices, poly.vertices[1])
-            push!(csg.indices, p)
-            push!(csg.vertices, poly.vertices[j])
-            push!(csg.indices, p + 1)
-            push!(csg.vertices, poly.vertices[j + 1])
-            push!(csg.indices, p + 2)
+            push!(csg.vertices, poly.vertices[1],
+                                poly.vertices[j],
+                                poly.vertices[j + 1])
+            push!(csg.indices, p, p + 1, p + 2)
 
             p = p + 3
         end
@@ -26,16 +24,16 @@ function fromPolygons(polygons)
     return csg
 end
 
-function toPolygons(model)
+function toPolygons(model::Solid{T}) where T
     list = Array{Polygon,1}();
     for i = 0:3:(length(model.indices) - 1)
 
-        triangle = Array{Vertex,1}()
+        triangle = Array{T,1}()
         for j = 0:2
             v = model.vertices[model.indices[i + j + 1] + 1]
             push!(triangle, copy(v));
         end
-        push!(list, Polygon(triangle, fromPoints(triangle[1].pos, triangle[2].pos, triangle[3].pos)))
+        push!(list, Polygon{T}(triangle, fromPoints(triangle[1], triangle[2], triangle[3])))
     end
     return list;
 end
@@ -63,9 +61,9 @@ r = bunion(c1, c2) # union of solids c1 and c2
 v = volume(r) # volume of union c1 c2
 ```
 """
-function bunion(first::Solid, second::Solid)
-    a = Node(nothing, nothing, nothing, Array{Polygon,1}())
-    b = Node(nothing, nothing, nothing, Array{Polygon,1}())
+function bunion(first::Solid{T}, second::Solid{T}) where T
+    a = Node{T}(nothing, nothing, nothing, Array{Polygon{T},1}())
+    b = Node{T}(nothing, nothing, nothing, Array{Polygon{T},1}())
 
     build(a, toPolygons(first));
     build(b, toPolygons(second));
@@ -103,9 +101,9 @@ r = bsubtract(c1, c2) # subtraction of c2 from c1
 v = volume(r) # volume of c1-c2
 ```
 """
-function bsubtract(first::Solid, second::Solid)
-    a = Node(nothing, nothing, nothing, Array{Polygon,1}())
-    b = Node(nothing, nothing, nothing, Array{Polygon,1}())
+function bsubtract(first::Solid{T}, second::Solid{T}) where T
+    a = Node{T}(nothing, nothing, nothing, Array{Polygon{T},1}())
+    b = Node{T}(nothing, nothing, nothing, Array{Polygon{T},1}())
 
     build(a, toPolygons(first));
     build(b, toPolygons(second));
@@ -144,9 +142,9 @@ r = bintersect(c1, c2) # intersection of c1 and c2
 v = volume(r)
 ```
 """
-function bintersect(first::Solid, second::Solid)
-    a = Node(nothing, nothing, nothing, Array{Polygon,1}())
-    b = Node(nothing, nothing, nothing, Array{Polygon,1}())
+function bintersect(first::Solid{T}, second::Solid{T}) where T
+    a = Node{T}(nothing, nothing, nothing, Array{Polygon{T},1}())
+    b = Node{T}(nothing, nothing, nothing, Array{Polygon{T},1}())
 
     build(a, toPolygons(first));
     build(b, toPolygons(second));
@@ -162,7 +160,7 @@ function bintersect(first::Solid, second::Solid)
 end
 
 function interpolate(vertex, other, t)
-    return Vertex([vertex.pos[1] + (other.pos[1]-vertex.pos[1])*t, vertex.pos[2] + (other.pos[2]-vertex.pos[2])*t, vertex.pos[3] + (other.pos[3]-vertex.pos[3])*t])
+    return vertex .+ (other .- vertex).*t
 end
 
 function fromPoints(a, b, c)
@@ -171,32 +169,32 @@ function fromPoints(a, b, c)
     return Plane(n, dot(n, a))
 end
 
-function splitPolygon(plane, polygon, coplanarFront, coplanarBack, front, back)
-    COPLANAR = 0
-    FRONT = 1
-    BACK = 2
-    SPANNING = 3
+function splitPolygon(plane::Plane{T}, polygon, coplanarFront, coplanarBack, front, back) where T
+    COPLANAR = 0x00
+    FRONT = 0x01
+    BACK = 0x02
+    SPANNING = 0x03
 
     # Classify each point as well as the entire polygon into one of the above four classes.
-    polygonType = 0
+    polygonType = 0x00
     types = Array{Int64,1}()
 
     for vertex in polygon.vertices
-        t = dot(plane.normal, vertex.pos) - plane.w
-        type::Int64 = (t < -PlaneEpsilon) ? BACK : ((t > PlaneEpsilon) ? FRONT : COPLANAR)
+        t = dot(plane.normal, vertex) - plane.w
+        type = (t < -PlaneEpsilon) ? BACK : ((t > PlaneEpsilon) ? FRONT : COPLANAR)
         polygonType |= type
         push!(types, type)
     end
 
-    if polygonType === COPLANAR
+    if polygonType == COPLANAR
         push!(dot(plane.normal, polygon.plane.normal) > 0 ? coplanarFront : coplanarBack, polygon)
-    elseif polygonType === FRONT
+    elseif polygonType == FRONT
         push!(front, polygon)
-    elseif polygonType === BACK
+    elseif polygonType == BACK
         push!(back, polygon)
-    elseif polygonType === SPANNING
-        f = Array{Vertex,1}()
-        b = Array{Vertex,1}()
+    elseif polygonType == SPANNING
+        f = Array{T,1}()
+        b = Array{T,1}()
 
         for i = 0:(length(polygon.vertices) - 1)
             j = (i + 1) % length(polygon.vertices)
@@ -208,28 +206,26 @@ function splitPolygon(plane, polygon, coplanarFront, coplanarBack, front, back)
             if ti != BACK push!(f, copy(vi)) end
             if ti != FRONT push!(b, copy(vi)) end
             if (ti | tj) == SPANNING
-                t = (plane.w - dot(plane.normal, vi.pos)) / dot(plane.normal, vj.pos - vi.pos)
+                t = (plane.w - dot(plane.normal, vi)) / dot(plane.normal, vj - vi)
                 v = interpolate(vi, vj, t)
                 push!(f, v)
                 push!(b, v)
             end
         end
 
-        if (length(f) >= 3) push!(front, Polygon(f, fromPoints(f[1].pos, f[2].pos, f[3].pos))) end
-        if (length(b) >= 3) push!(back, Polygon(b, fromPoints(b[1].pos, b[2].pos, b[3].pos))) end
+        if (length(f) >= 3) push!(front, Polygon{T}(f, fromPoints(f[1], f[2], f[3]))) end
+        if (length(b) >= 3) push!(back, Polygon{T}(b, fromPoints(b[1], b[2], b[3]))) end
     end
 end
 
 function invert(node::Node)
     for poly in node.polygons
         reverse!(poly.vertices)
-        poly.plane.normal = -1 * poly.plane.normal
-        poly.plane.w = -1 * poly.plane.w
+        poly.plane = Plane(-1 .* poly.plane.normal, -1 * poly.plane.w)
     end
 
     if node.plane !== nothing
-        node.plane.normal = -1 * node.plane.normal
-        node.plane.w = -1 * node.plane.w
+        node.plane = Plane(-1 .* node.plane.normal, -1 * node.plane.w)
     end
 
     if node.front !== nothing invert(node.front) end
@@ -239,13 +235,13 @@ function invert(node::Node)
     node.front, node.back = node.back, node.front
 end
 
-function clipPolygons(node::Node, polygons::Array{Polygon,1})
+function clipPolygons(node::Node{T}, polygons::Array{Polygon{T},1}) where T
     polysize = length(polygons)
 
     if node.plane === nothing return copy(polygons) end
 
-    front = Array{Polygon,1}()
-    back = Array{Polygon,1}()
+    front = Array{Polygon{T},1}()
+    back = Array{Polygon{T},1}()
 
     for polygon in polygons
         splitPolygon(node.plane, polygon, front, back, front, back);
@@ -258,7 +254,7 @@ function clipPolygons(node::Node, polygons::Array{Polygon,1})
     if node.back !== nothing
         back = clipPolygons(node.back, back)
     else
-        back = Array{Polygon,1}()
+        back = Array{Polygon{T},1}()
     end
 
     return vcat(front, back)
@@ -280,7 +276,7 @@ function allPolygons(node::Node)
     return polygons
 end
 
-function build(node::Node, polygons)
+function build(node::Node{T}, polygons) where T
     if length(polygons) === 0 return end
 
     if node.plane === nothing node.plane = deepcopy(polygons[1].plane) end
@@ -293,12 +289,12 @@ function build(node::Node, polygons)
     end
 
     if length(front) > 0
-        if node.front === nothing node.front = Node(nothing, nothing, nothing, Array{Polygon,1}()) end
+        if node.front === nothing node.front = Node{T}(nothing, nothing, nothing, Array{Polygon,1}()) end
         build(node.front, front)
     end
 
     if length(back) > 0
-        if node.back === nothing node.back = Node(nothing, nothing, nothing, Array{Polygon,1}()) end
+        if node.back === nothing node.back = Node{T}(nothing, nothing, nothing, Array{Polygon,1}()) end
         build(node.back, back)
     end
 end
@@ -325,28 +321,28 @@ Main.SolidModeling.Solid(...)
 ```
 """
 function cube(xMin::Float64, yMin::Float64, zMin::Float64, xMax::Float64, yMax::Float64, zMax::Float64)::Solid
-    v1 = Vertex([xMin, yMin, zMax])
-    v2 = Vertex([xMin, yMax, zMax])
-    v3 = Vertex([xMax, yMax, zMax])
-    v4 = Vertex([xMax, yMin, zMax])
-    v5 = Vertex([xMin, yMin, zMin])
-    v6 = Vertex([xMin, yMax, zMin])
-    v7 = Vertex([xMax, yMax, zMin])
-    v8 = Vertex([xMax, yMin, zMin])
+    v1 = [xMin, yMin, zMax]
+    v2 = [xMin, yMax, zMax]
+    v3 = [xMax, yMax, zMax]
+    v4 = [xMax, yMin, zMax]
+    v5 = [xMin, yMin, zMin]
+    v6 = [xMin, yMax, zMin]
+    v7 = [xMax, yMax, zMin]
+    v8 = [xMax, yMin, zMin]
 
-    f1p = Polygon([v1, v4, v3, v2], fromPoints(v1.pos, v4.pos, v3.pos))
-    f2p = Polygon([v7, v8, v5, v6], fromPoints(v7.pos, v8.pos, v5.pos))
-    f3p = Polygon([v1, v2, v6, v5], fromPoints(v1.pos, v2.pos, v6.pos))
-    f4p = Polygon([v2, v3, v7, v6], fromPoints(v2.pos, v3.pos, v7.pos))
-    f5p = Polygon([v3, v4, v8, v7], fromPoints(v3.pos, v4.pos, v8.pos))
-    f6p = Polygon([v4, v1, v5, v8], fromPoints(v4.pos, v1.pos, v5.pos))
+    f1p = Polygon([v1, v4, v3, v2], fromPoints(v1, v4, v3))
+    f2p = Polygon([v7, v8, v5, v6], fromPoints(v7, v8, v5))
+    f3p = Polygon([v1, v2, v6, v5], fromPoints(v1, v2, v6))
+    f4p = Polygon([v2, v3, v7, v6], fromPoints(v2, v3, v7))
+    f5p = Polygon([v3, v4, v8, v7], fromPoints(v3, v4, v8))
+    f6p = Polygon([v4, v1, v5, v8], fromPoints(v4, v1, v5))
 
     polys = [f1p, f2p, f3p, f4p, f5p, f6p];
 
     return fromPolygons(polys);
 end
 
-function signedVolumeOfTriangle(p1::Array{Float64}, p2::Array{Float64}, p3::Array{Float64})
+function signedVolumeOfTriangle(p1, p2, p3)
    	v321 = p3[1] * p2[2] * p1[3]
    	v231 = p2[1] * p3[2] * p1[3]
    	v312 = p3[1] * p1[2] * p2[3]
@@ -372,7 +368,7 @@ function volume(c::Solid)::Float64
     volume = 0.0;
 
     for i = 0:3:(length(c.indices) - 1)
-        dv = signedVolumeOfTriangle(c.vertices[i + 1].pos, c.vertices[i + 2].pos, c.vertices[i + 3].pos)
+        dv = signedVolumeOfTriangle(c.vertices[i + 1], c.vertices[i + 2], c.vertices[i + 3])
         volume += dv
     end
 

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -1,27 +1,22 @@
-mutable struct Vertex
-    pos::Array{Float64}
-end
 
-Base.copy(s::Vertex) = Vertex(copy(s.pos))
-
-mutable struct Plane
-    normal::Array{Float64}
+struct Plane{T}
+    normal::T
     w::Float64
 end
 
-mutable struct Polygon
-    vertices::Array{Vertex,1}
+mutable struct Polygon{T}
+    vertices::Array{T,1}
     plane::Plane
 end
 
-mutable struct Node
-    plane::Union{Nothing,Plane}
-    front::Union{Nothing,Node}
-    back::Union{Nothing,Node}
-    polygons::Array{Polygon,1}
+mutable struct Node{T}
+    plane::Union{Nothing,Plane{T}}
+    front::Union{Nothing,Node{T}}
+    back::Union{Nothing,Node{T}}
+    polygons::Array{Polygon{T},1}
 end
 
-mutable struct Solid
-    vertices::Array{Vertex,1}
-    indices::Array{Int64,1}
+struct Solid{T}
+    vertices::Array{T,1}
+    indices::Array{Int,1}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,7 @@ function cubeSubtract()
     c1 = cube([0.5, 0.5, 0.5], 1.0, 1.0, 1.0)
     c2 = cube(0.5, 0.5, 0.5, 2.0, 2.0, 2.0)
     r = bsubtract(c1, c2)
+    @show r
 
     v = volume(r)
 
@@ -33,7 +34,7 @@ end
 function cubeIntersect()
     c1 = cube(0.0, 0.0, 0.0, 1.0, 1.0, 1.0)
     c2 = cube(0.5, 0.5, 0.5, 2.0, 2.0, 2.0)
-
+    @show bintersect(c1, c2)
     v = volume(bintersect(c1, c2))
 
     return v
@@ -45,5 +46,3 @@ end
     @test isapprox(cubeSubtract(), (1-0.125))
     @test isapprox(cubeIntersect(), 0.125)
 end
-
-


### PR DESCRIPTION
The Basic idea here is to remove the mutable `Vertex` type and replace with any generic `AbstractArray` type. This should allow this to be used with e.g. `StaticArrays` or `GeometryBasics`, and give somewhat better performance. 

I am opening as a draft because I still have yet to test with Geometry libraries and might have to make other changes for this to work. BTW, thanks for writing this, it is really cool! 